### PR TITLE
Fix loss function computation for hard clustering

### DIFF
--- a/jMEF/BregmanHardClustering.java
+++ b/jMEF/BregmanHardClustering.java
@@ -439,13 +439,15 @@ public class BregmanHardClustering {
 		for (int i=0; i<n; i++){
 			double min = Double.MAX_VALUE;
 			for (int j=0; j<m; j++){
+				double tmp = 0;
 				if (type==CLUSTERING_TYPE.RIGHT_SIDED)
-					min = f.EF.BD(f.param[i], g.param[j]);
+					tmp = f.EF.BD(f.param[i], g.param[j]);
 				else if (type==CLUSTERING_TYPE.LEFT_SIDED)
-					min = f.EF.BD(g.param[j], f.param[i]);
+					tmp = f.EF.BD(g.param[j], f.param[i]);
 				else if (type==CLUSTERING_TYPE.SYMMETRIC){
-					min = 0.5 * ( f.EF.BD(f.param[i], g.param[j]) + f.EF.BD(g.param[j], f.param[i]) );
+					tmp = 0.5 * ( f.EF.BD(f.param[i], g.param[j]) + f.EF.BD(g.param[j], f.param[i]) );
 				}
+				min = Math.min(min, tmp);
 			}
 			value += min;
 		}


### PR DESCRIPTION
getLossFunction method in BregmanHardClustering was previously always returning sum of divergences to only the last component of the MixtureModel 'g'.  This commit instead uses the component of 'g' with the minimum divergence to the current component of 'f'.
